### PR TITLE
Switch monaco-editor-core to monaco-editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 `Monaco-volar` has external dependency Onigasm (to highlight code).
 
 ```console
-pnpm add monaco-volar monaco-editor-core onigasm
+pnpm add monaco-volar monaco-editor onigasm
 
 # or
 
-yarn add monaco-volar monaco-editor-core onigasm
+yarn add monaco-volar monaco-editor onigasm
 
 ```
 
@@ -22,7 +22,7 @@ yarn add monaco-volar monaco-editor-core onigasm
 Import `monaco-volar` when you are using monaco. It will register vue as a language automatic.
 
 ```ts
-import 'monaco-editor-core'
+import 'monaco-editor'
 import 'monaco-volar'
 ```
 
@@ -50,7 +50,7 @@ loadOnigasm()
 Now we can apply grammars into monaco editor instance.
 
 ```ts
-import { editor } from "monaco-editor-core";
+import { editor } from "monaco-editor";
 import { loadGrammars, loadTheme } from "monaco-volar";
 
 const theme = loadTheme()
@@ -70,7 +70,7 @@ loadGrammars(editorInstance);
 We need to let monaco know where and how to load out worker when using Vue.
 
 ```ts
-import editorWorker from "monaco-editor-core/esm/vs/editor/editor.worker?worker";
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import vueWorker from "monaco-volar/vue.worker?worker";
 
 function loadMonacoEnv() {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@vue/runtime-dom": "^3.2.37",
     "@vue/shared": "^3.2.37",
     "esbuild": "^0.14.43",
-    "monaco-editor-core": "^0.33.0",
     "monaco-editor-textmate": "^3.0.0",
     "monaco-textmate": "^3.0.1",
     "onigasm": "^2.2.5",
@@ -48,11 +47,11 @@
     "vue": "^3.2.37"
   },
   "peerDependencies": {
-    "monaco-editor-core": "^0.33.0",
+    "monaco-editor": "^0.33.0",
     "onigasm": "^2.2.5"
   },
   "dependencies": {
-    "monaco-editor-core": "^0.33.0",
+    "monaco-editor": "^0.33.0",
     "onigasm": "^2.2.5",
     "typesafe-path": "^0.2.1",
     "vscode-uri": "^3.0.6"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ specifiers:
   '@vue/runtime-dom': ^3.2.37
   '@vue/shared': ^3.2.37
   esbuild: ^0.14.43
-  monaco-editor-core: ^0.33.0
+  monaco-editor: ^0.33.0
   monaco-editor-textmate: ^3.0.0
   monaco-textmate: ^3.0.1
   onigasm: ^2.2.5
@@ -22,7 +22,7 @@ specifiers:
   vue: ^3.2.37
 
 dependencies:
-  monaco-editor-core: 0.33.0
+  monaco-editor: 0.33.0
   onigasm: 2.2.5
   typesafe-path: 0.2.1
   vscode-uri: 3.0.6
@@ -35,7 +35,7 @@ devDependencies:
   '@vue/runtime-dom': 3.2.37
   '@vue/shared': 3.2.37
   esbuild: 0.14.43
-  monaco-editor-textmate: 3.0.0_monaco-textmate@3.0.1
+  monaco-editor-textmate: 3.0.0_nurowwtvogix47pnszh4m7lsnu
   monaco-textmate: 3.0.1_onigasm@2.2.5
   path-browserify: 1.0.1
   prettier: 2.6.2
@@ -846,7 +846,6 @@ packages:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
     dependencies:
       yallist: 3.1.1
-    dev: false
 
   /lru-cache/6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
@@ -868,18 +867,18 @@ packages:
       brace-expansion: 2.0.1
     dev: true
 
-  /monaco-editor-core/0.33.0:
-    resolution: {integrity: sha512-Kzxak8jnMS8vI08DcseBuOfeQlcVPpGXO210D8M+QnaNR92s4IYzgUeiow/Hld9Gi5pGvjDbPsdUXkPewoTA5g==}
-    dev: false
-
-  /monaco-editor-textmate/3.0.0_monaco-textmate@3.0.1:
+  /monaco-editor-textmate/3.0.0_nurowwtvogix47pnszh4m7lsnu:
     resolution: {integrity: sha1-qQUXOA1eUjBK73gO6+q59oerm2c=}
     peerDependencies:
       monaco-editor: 0.x.x
       monaco-textmate: ^3.0.0
     dependencies:
+      monaco-editor: 0.33.0
       monaco-textmate: 3.0.1_onigasm@2.2.5
     dev: true
+
+  /monaco-editor/0.33.0:
+    resolution: {integrity: sha512-VcRWPSLIUEgQJQIE0pVT8FcGBIgFoxz7jtqctE+IiCxWugD0DwgyQBcZBhdSrdMC84eumoqMZsGl2GTreOzwqw==}
 
   /monaco-textmate/3.0.1_onigasm@2.2.5:
     resolution: {integrity: sha1-ttJtJmqhLtr/cGna4NbjdHy6XNc=}
@@ -909,7 +908,6 @@ packages:
     resolution: {integrity: sha1-zE0qeaD6C2TK7B9MfqNnWFpnaJI=}
     dependencies:
       lru-cache: 5.1.1
-    dev: false
 
   /path-browserify/1.0.1:
     resolution: {integrity: sha1-2YRUqcN1PVeQhg8W9ohnueRr4f0=}
@@ -1227,7 +1225,6 @@ packages:
 
   /yallist/3.1.1:
     resolution: {integrity: sha1-27fa+b/YusmrRev2ArjLrQ1dCP0=}
-    dev: false
 
   /yallist/4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}

--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -1,1 +1,1 @@
-export const externals = ["monaco-editor-core", "onigasm"];
+export const externals = ["monaco-editor", "onigasm"];

--- a/src/code2monaco.ts
+++ b/src/code2monaco.ts
@@ -7,7 +7,7 @@ import {
   MarkerTag,
   MarkerSeverity,
   Position,
-} from "monaco-editor-core";
+} from "monaco-editor";
 import * as vscode from "vscode-languageserver-protocol";
 
 export function asCompletionList(

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,4 +1,4 @@
-import { editor, IDisposable } from "monaco-editor-core";
+import { editor, IDisposable } from "monaco-editor";
 import type { LanguageServiceDefaults } from "./monaco.contribution";
 import { WorkerAccessor } from "./types";
 import type { VueWorker } from "./vueWorker";

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="vite/client" />
 
-declare module "monaco-editor-core/esm/vs/editor/editor.worker" {
+declare module "monaco-editor/esm/vs/editor/editor.worker" {
   export function initialize(
     callback: (ctx: any, createData: any) => any
   ): void;

--- a/src/grammars/index.ts
+++ b/src/grammars/index.ts
@@ -1,4 +1,4 @@
-import * as monaco from 'monaco-editor-core';
+import * as monaco from 'monaco-editor';
 import { wireTmGrammars } from 'monaco-editor-textmate';
 import { Registry, type IGrammarDefinition } from 'monaco-textmate';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { editor } from "monaco-editor-core";
+import { editor } from "monaco-editor";
 import "./monaco.contribution";
 
 export const loadTheme = async () => {

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -1,5 +1,5 @@
 import type * as mode from "./vueMode";
-import { Emitter, type IEvent, languages } from "monaco-editor-core";
+import { Emitter, type IEvent, languages } from "monaco-editor";
 import { debounce, normalizePath } from "./utils";
 import * as path from "typesafe-path";
 
@@ -72,7 +72,7 @@ const modeConfigurationDefault: Required<ModeConfiguration> = {
 export const vueDefaults: LanguageServiceDefaults =
   new LanguageServiceDefaultsImpl("vue", modeConfigurationDefault);
 
-declare module "monaco-editor-core" {
+declare module "monaco-editor" {
   export namespace languages {
     export let vue: { vueDefaults: LanguageServiceDefaults };
   }

--- a/src/monaco2code.ts
+++ b/src/monaco2code.ts
@@ -1,4 +1,4 @@
-import { Position, IRange, languages } from "monaco-editor-core";
+import { Position, IRange, languages } from "monaco-editor";
 import * as vscode from "vscode-languageserver-protocol";
 
 export function asPosition(position: Position): vscode.Position {

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -1,4 +1,4 @@
-import { Uri, languages } from "monaco-editor-core";
+import { Uri, languages } from "monaco-editor";
 import { getOrCreateModel } from "./utils";
 import * as path from "typesafe-path";
 

--- a/src/prepare.ts
+++ b/src/prepare.ts
@@ -18,12 +18,12 @@ export function prepareVirtualFiles() {
   const libDtsUrl = Uri.parse("file:///lib.d.ts");
   const libPromiseUrl = Uri.parse("file:///lib.es2015.promise.d.ts");
 
-  const libEs5Model = getOrCreateModel(libEs5Url, undefined, libEs5Content);
-  const libDomModel = getOrCreateModel(libDomUrl, undefined, libDomContent);
-  const libDtsModel = getOrCreateModel(libDtsUrl, undefined, libDtsContent);
+  const libEs5Model = getOrCreateModel(libEs5Url, "vue", libEs5Content);
+  const libDomModel = getOrCreateModel(libDomUrl, "vue", libDomContent);
+  const libDtsModel = getOrCreateModel(libDtsUrl, "vue", libDtsContent);
   const libPromiseModel = getOrCreateModel(
     libPromiseUrl,
-    undefined,
+    "vue",
     libPromiseContent
   );
 
@@ -41,25 +41,25 @@ export function prepareVirtualFiles() {
     "file:///node_modules/%40vue/reactivity/index.d.ts"
   );
 
-  const vueModel = getOrCreateModel(vueUrl, undefined, vueContent);
+  const vueModel = getOrCreateModel(vueUrl, "vue", vueContent);
   const vueRuntimeDomModel = getOrCreateModel(
     vueRuntimeDomUrl,
-    undefined,
+    "vue",
     vueRuntimeDomContent
   );
   const vueRuntimeCoreModel = getOrCreateModel(
     vueRuntimeCoreUrl,
-    undefined,
+    "vue",
     vueRuntimeCoreContent
   );
   const vueSharedModel = getOrCreateModel(
     vueSharedUrl,
-    undefined,
+    "vue",
     vueSharedContent
   );
   const vueReactivityModel = getOrCreateModel(
     vueReactivityUrl,
-    undefined,
+    "vue",
     vueReactivityContent
   );
 

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,4 +1,4 @@
-import type { worker } from "monaco-editor-core";
+import type { worker } from "monaco-editor";
 import * as ts from "typescript/lib/tsserverlibrary";
 import {
   createLanguageService,

--- a/src/themes/converted.ts
+++ b/src/themes/converted.ts
@@ -1,4 +1,4 @@
-import type * as monaco from 'monaco-editor-core';
+import type * as monaco from 'monaco-editor';
 
 export const theme: monaco.editor.IStandaloneThemeData = {
   inherit: false,

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,4 +1,4 @@
-import { editor } from 'monaco-editor-core'
+import { editor } from 'monaco-editor'
 import { theme } from './converted'
 
 export async function loadTheme() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import type { Uri, languages } from "monaco-editor-core";
+import type { Uri, languages } from "monaco-editor";
 
 export interface WorkerAccessor<T> {
   (...more: Uri[]): Promise<T>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { Uri, editor, IDisposable } from "monaco-editor-core";
+import { Uri, editor, IDisposable } from "monaco-editor";
 import * as path from "typesafe-path";
 
 export function debounce(fn: Function, n = 100) {

--- a/src/vue.worker.ts
+++ b/src/vue.worker.ts
@@ -1,4 +1,4 @@
-import * as worker from "monaco-editor-core/esm/vs/editor/editor.worker";
+import * as worker from "monaco-editor/esm/vs/editor/editor.worker";
 import { VueWorker } from "./vueWorker";
 
 self.onmessage = () => {

--- a/src/vueMode.ts
+++ b/src/vueMode.ts
@@ -13,7 +13,7 @@ import {
   languages,
   Range,
   type IDisposable,
-} from "monaco-editor-core";
+} from "monaco-editor";
 import { createDiagnosticsAdapter } from "./diagnostics";
 import { asDisposable, disposeAll } from "./utils";
 import { IVueAdaptor, WorkerAccessor } from "./types";

--- a/src/vueWorker.ts
+++ b/src/vueWorker.ts
@@ -1,4 +1,4 @@
-import type { worker } from "monaco-editor-core";
+import type { worker } from "monaco-editor";
 import { getLanguageServiceAndDocumentsService } from "./services";
 import * as vscode from "vscode-languageserver-protocol";
 

--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -1,6 +1,6 @@
 import { LanguageServiceDefaults } from "./monaco.contribution";
 import type { ICreateData, VueWorker } from "./vueWorker";
-import { type IDisposable, Uri, editor } from "monaco-editor-core";
+import { type IDisposable, Uri, editor } from "monaco-editor";
 
 const STOP_WHEN_IDLE_FOR = 2 * 60 * 1000; // 2min
 

--- a/tests/env.ts
+++ b/tests/env.ts
@@ -1,4 +1,4 @@
-import editorWorker from "monaco-editor-core/esm/vs/editor/editor.worker?worker";
+import editorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
 import vueWorker from "../src/vue.worker?worker";
 import * as onigasm from "onigasm";
 import onigasmWasm from "onigasm/lib/onigasm.wasm?url";

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -1,5 +1,5 @@
 import { loadMonacoEnv, loadOnigasm } from "./env";
-import { editor, Uri } from "monaco-editor-core";
+import { editor, Uri } from "monaco-editor";
 import { loadGrammars, loadTheme, prepareVirtualFiles } from "../src/index";
 import { getOrCreateModel } from "../src/utils";
 import data from "./Test.vue?raw";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
     include: [
       "path-browserify",
       "@volar/vue-language-service",
-      "monaco-editor-core",
+      "monaco-editor",
     ],
   },
   resolve: {


### PR DESCRIPTION
## What this PR does / why we need it:
hi @Kingwl  
I have switched monaco-editor-core to monaco-editor to fix https://github.com/Kingwl/monaco-volar/issues/8

From https://github.com/Microsoft/monaco-editor/issues/941 and https://github.com/Microsoft/monaco-editor/blob/main/CONTRIBUTING.md#a-brief-explanation-on-the-source-code-structure,  monaco-editor includes the languages definitions and include monaco-editor-core. In some case, when build a custom editor , it needs default languages api from monaco-editor like this
```ts
monaco.languages.typescript.javascriptDefaults.addExtraLib()
```




